### PR TITLE
test: memoryview of Apache Arrow buffers (#9)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,6 +40,8 @@ jobs:
           profile: minimal
       - name: Install pytest
         run: pip install pytest
+      - name: Install pyarrow
+        run: pip install pyarrow
       - name: Run build.py
         run: python -u tests/build.py
       - name: Run pytest

--- a/tests/test_blake3.py
+++ b/tests/test_blake3.py
@@ -91,6 +91,14 @@ def test_buffer_types():
     assert incremental.digest() == blake3(b"foofoofoofoo").digest()
 
 
+def test_arrow():
+    import pyarrow as pa
+    ar = pa.array(['foo', 'bar'])
+    blake = blake3()
+    blake.update(memoryview(ar.buffers()[1]))
+    blake.update(memoryview(ar.buffers()[2]))
+
+
 def test_string_fails():
     try:
         blake3("a string")


### PR DESCRIPTION
This tests the issue mentioned in #9, which gives me
```

    def test_arrow():
        import pyarrow as pa
        ar = pa.array(['foo', 'bar'])
        blake = blake3()
>       blake.update(memoryview(ar.buffers()[1]))
E       BufferError: Incompatible type as buffer

tests/test_blake3.py:98: BufferError
```

