### PR TITLE
Add `copy` method and `name` attribute.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,10 +153,10 @@ fn blake3(_: Python, m: &PyModule) -> PyResult<()> {
             )
         }
 
-        /// Return a copy of a Blake3Hasher object.
-        /// The usual caveats of multithreading as mentioned in `./README.md` apply here.
+        /// Return a copy of the Blake3Hasher hash object.
+        /// The usual caveats of Python multithreading apply here.
         /// Calling `copy` in a multi-threaded situation without a lock on the copied object
-        /// will likely result in non-deterministic behavior.
+        /// will likely result in incorrect output. 
         fn copy(&self) -> Blake3Hasher {
             Blake3Hasher {
                 rust_hasher: self.rust_hasher.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,13 @@ fn blake3(_: Python, m: &PyModule) -> PyResult<()> {
 
     #[pymethods]
     impl Blake3Hasher {
+        #[getter]
+        /// Returns the name of the hashing algorithm.
+        fn name(&self) -> &str {
+            "blake3"
+        }
+
+
         /// Add input bytes to the hasher. You can call this any number of
         /// times.
         ///
@@ -145,6 +152,17 @@ fn blake3(_: Python, m: &PyModule) -> PyResult<()> {
                 multithreading.unwrap_or(false),
             )
         }
+
+        /// Return a copy of a Blake3Hasher object.
+        /// The usual caveats of multithreading as mentioned in `./README.md` apply here.
+        /// Calling `copy` in a multi-threaded situation without a lock on the copied object
+        /// will likely result in non-deterministic behavior.
+        fn copy(&self) -> Blake3Hasher {
+            Blake3Hasher {
+                rust_hasher: self.rust_hasher.clone(),
+            }
+        }
+
 
         /// Finalize the hasher and return the resulting hash as bytes. This
         /// does not modify the hasher, and calling it twice will give the same

--- a/tests/test_blake3.py
+++ b/tests/test_blake3.py
@@ -204,6 +204,8 @@ def test_copy_basic():
 
 
 def test_copy_multithreading():
+    """This test is somewhat redundant and takes a belt-and-suspenders approach. If the rest
+    of the tests pass but this test fails, something *very* weird is going on. """
     b = make_input(10 ** 6)
     b2 = make_input(10 ** 6)
     b3 = make_input(10 ** 6)

--- a/tests/test_blake3.py
+++ b/tests/test_blake3.py
@@ -182,3 +182,45 @@ def test_key_context_incompatible():
         pass
     else:
         assert False, "expected a type error"
+
+
+def test_name():
+    b = blake3()
+    assert b.name == "blake3"
+
+
+def test_copy_basic():
+    b = make_input(10**6)
+    b2 = make_input(10**6)
+    h1 = blake3(b)
+    expected = h1.digest()
+    h2 = h1.copy()
+    assert expected == h2.digest()
+    h1.update(b2)
+    expected2 = h1.digest()
+    assert expected2 != h2.digest(), "Independence test failed"
+    h2.update(b2)
+    assert expected2 == h2.digest(), "Update state of copy diverged from expected state"
+
+
+def test_copy_multithreading():
+    b = make_input(10 ** 6)
+    b2 = make_input(10 ** 6)
+    b3 = make_input(10 ** 6)
+
+    h1 = blake3(b, multithreading=True)
+    expected = h1.digest()
+    h2 = h1.copy()
+    h3 = blake3(b, multithreading=True)
+    assert expected == h2.digest()
+    h1.update(b2, multithreading=True)
+    h3.update(b2, multithreading=True)
+    h3.update(b3, multithreading=True)
+
+    expected2 = h1.digest()
+    assert expected2 != h2.digest(), "Independence test failed"
+    h2.update(b2, multithreading=True)
+    assert expected2 == h2.digest(), "Update state of copy diverged from expected state"
+
+    h2.update(b3, multithreading=True)
+    assert h2.digest() == h3.digest(), "Update state of copy diverged from expected state"


### PR DESCRIPTION
https://github.com/oconnor663/blake3-py/issues/16

This adds a `copy()` method which returns an independent
hasher with the same state, and a `name` attribute which
just returns 'blake3'. This bring the implementation interface
into agreement with other python hashlib hash functions.