### PR TITLE
Build macOS arm64 wheels on macOS-11 runners

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           # This list should be kept in sync with tag.yml.
           { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu", name: "Linux x64" },
           { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin",      name: "macOS x64" },
-          { os: "macOS-latest",   python-architecture: "x64", rust-target: "aarch64-apple-darwin",     name: "macOS ARM" },
+          { os: "macOS-11",   python-architecture: "x64", rust-target: "aarch64-apple-darwin",     name: "macOS ARM" },
           { os: "windows-latest", python-architecture: "x64", rust-target: "x86_64-pc-windows-msvc",   name: "Windows x86" },
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc",     name: "Windows x64" },
         ]
@@ -26,11 +26,11 @@ jobs:
           # aarch64 macOS has no support for Python version lower than 3.8
           - python-version: 3.6
             platform:
-              os: "macOS-latest"
+              os: "macOS-11"
               rust-target: "aarch64-apple-darwin"
           - python-version: 3.7
             platform:
-              os: "macOS-latest"
+              os: "macOS-11"
               rust-target: "aarch64-apple-darwin"
       fail-fast: false
     env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
           # This list should be kept in sync with push.yml.
           { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu", name: "Linux x64" },
           { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin",      name: "macOS x64" },
-          { os: "macOS-latest",   python-architecture: "x64", rust-target: "aarch64-apple-darwin",     name: "macOS ARM" },
+          { os: "macOS-11",   python-architecture: "x64", rust-target: "aarch64-apple-darwin",     name: "macOS ARM" },
           { os: "windows-latest", python-architecture: "x64", rust-target: "x86_64-pc-windows-msvc",   name: "Windows x86" },
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc",     name: "Windows x64" },
         ]
@@ -24,11 +24,11 @@ jobs:
           # aarch64 macOS has no support for Python version lower than 3.8
           - python-version: 3.6
             platform:
-              os: "macOS-latest"
+              os: "macOS-11"
               rust-target: "aarch64-apple-darwin"
           - python-version: 3.7
             platform:
-              os: "macOS-latest"
+              os: "macOS-11"
               rust-target: "aarch64-apple-darwin"
       fail-fast: false
     env:


### PR DESCRIPTION
Xcode Command Tools on macOS-latest (macOS-10.15) doesn't have support for compiling to arm64 although a full Xcode install does support it.