### PR TITLE
c_impl: fix usedforsecurity argument variable type, fixes #34

### DIFF
--- a/c_impl/blake3module.c
+++ b/c_impl/blake3module.c
@@ -53,7 +53,7 @@ static PyObject *Blake3_new(PyTypeObject *type, PyObject *args,
   Py_buffer key = {0};
   const char *derive_key_context = NULL;
   Py_ssize_t max_threads = 1;
-  bool usedforsecurity = true;
+  int usedforsecurity = 1;
 
   PyObject *ret = NULL;
 


### PR DESCRIPTION
the python docs state that this must be int (not: bool).

as seen in #34, using the wrong type here seems to overflow the variable
and leads to a wrong value in max_threads, which leads to that strange
test failure.