### PR TITLE
Update maturin version to ~=1.0

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,7 +48,7 @@ jobs:
           profile: minimal
       - name: install maturin
         # Keep the Maturin version in sync with pyproject.toml.
-        run: pip install "maturin>=0.14,<0.15"
+        run: pip install "maturin~=1.0"
         # On Linux we'll run Maturin in a Docker container.
         if: matrix.platform.os != 'ubuntu-latest'
       - name: build wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Keep the Maturin version in sync with tag.yml.
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin~=1.0"]
 build-backend = "maturin"


### PR DESCRIPTION
This allows building blake3 with maturin 1.0, 1.1, 1.2 and future compatible versions.

The package was built and tested with each latest minor version of maturin since 0.14 (0.15.3, 1.0.1, 1.1.0 and 1.2.3) by incrementally increasing the upper bound and running :

```
# edit version then :
pip install --verbose --no-binary :all: . && pytest
```

https://www.maturin.rs/changelog