### PR TITLE
Update all Rust dependencies to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+
+version: 2
+updates:
+ # Enable updates for GitHub Actions (grouped)
+  - package-ecosystem: "github-actions"
+    target-branch: "master"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+  # Enable updates for Cargo
+  - package-ecosystem: "cargo"
+    target-branch: "master"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -80,7 +80,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -113,7 +113,7 @@ jobs:
     name: "mypy"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -71,7 +71,7 @@ jobs:
     name: sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -97,7 +97,7 @@ jobs:
       - sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 neon = ["blake3/neon"]
 
 [dependencies]
-blake3 = { version = "1.0.0", features = ["rayon"] }
-hex = "0.4.2"
-pyo3 = { version = "0.19.0", features = ["extension-module"] }
-rayon = "1.2.1"
+blake3 = { version = "1.5.0", features = ["rayon"] }
+hex = "0.4.3"
+pyo3 = { version = "0.20.0", features = ["extension-module"] }
+rayon = "1.8.0"


### PR DESCRIPTION
As per the title, updates all the Rust dependencies to the latest versions and adds a Dependabot configuration for a monthly check on updating those.

Also updated the actions while I was at it.

Heads up that actions-rs/toolchain@v1 is now archived, and hadn't seen an update in 3 years anyway.  https://github.com/dtolnay/rust-toolchain appears to be the general replacement, but it's not a drop in, so I didn't do this.