### PR TITLE
Bump maturin, pyo3, add free-threaded 3.13t wheel

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -33,7 +33,6 @@ jobs:
         - { os: windows-latest, target: i686 }
 
     runs-on: ${{ matrix.os }}
-
     steps:
     - uses: actions/checkout@v4
 
@@ -49,7 +48,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.13'
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -34,9 +34,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      PYO3_PRINT_CONFIG: 1
-
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -33,6 +33,10 @@ jobs:
         - { os: windows-latest, target: i686 }
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      - PYO3_PRINT_CONFIG: 1
+
     steps:
     - uses: actions/checkout@v4
 
@@ -48,7 +52,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
+        args: --release --out dist --interpreter '3.13'
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -48,7 +48,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 ${{ matrix.os == 'windows-latest' && '' || '3.13t' }}'
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      - PYO3_PRINT_CONFIG: 1
+      PYO3_PRINT_CONFIG: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -48,7 +48,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 ${{ matrix.os == 'windows-latest' && '' || '3.13t' }}'
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -48,7 +48,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13'
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ neon = ["blake3/neon"]
 [dependencies]
 blake3 = { version = "1.5", features = ["mmap", "rayon"] }
 hex = "0.4.2"
-pyo3 = { version = "0.23.1", features = ["extension-module"] }
+pyo3 = { version = "0.23.3", features = ["extension-module"] }
 rayon = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ neon = ["blake3/neon"]
 [dependencies]
 blake3 = { version = "1.5", features = ["mmap", "rayon"] }
 hex = "0.4.2"
-pyo3 = { version = "0.23.3", features = ["extension-module"] }
+pyo3 = { version = "0.23.3", features = ["extension-module", "generate-import-lib"] }
 rayon = "1.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-# TODO: Remove this pin once
-# https://github.com/PyO3/maturin/pull/2332#issuecomment-2507336466
-# is resolved, one way or the other.
-requires = ["maturin==1.7.5"]
+requires = ["maturin>=1.0,<2"]
 build-backend = "maturin"


### PR DESCRIPTION
- Add `3.13t` free-threaded python wheels ([supported](https://github.com/PyO3/maturin/releases/tag/v1.7.6) as of maturin 1.7.6)
- Unpin maturin again: https://github.com/pypa/gh-action-pypi-publish/issues/308 is fixed by https://github.com/pypa/gh-action-pypi-publish/pull/309 (still unreleased)
- Bump pyo3 to avoid this bug: https://github.com/PyO3/pyo3/issues/4757 merged and 0.23.3 [released](https://github.com/PyO3/pyo3/pull/4745#issuecomment-2515693312) to crates.io

ready for review but still need to bump version after release of gh-action-pypi-publish ^