### PR TITLE
Fix windows 3.13t wheels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   directory: /
   schedule:
     interval: monthly
-  groups:
-    github-actions:
-      patterns:
-      - '*'
+- package-ecosystem: cargo
+  directory: /
+  schedule:
+    interval: monthly

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -67,7 +67,7 @@ jobs:
         python-version: '3.13t'
         architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
 
-    - uses: PyO3/maturin-action@v1
+    - uses: PyO3/maturin-action@v1.45.0
       with:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux }}
@@ -89,7 +89,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: PyO3/maturin-action@v1
+    - uses: PyO3/maturin-action@v1.45.0
       with:
         command: sdist
         args: --out dist

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -51,6 +51,8 @@ jobs:
         args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
+      env:
+        LIBPATH: ${{ env.pythonLocation }}\lib
 
     - run: ${{ (matrix.os == 'windows-2025' && 'dir') || 'ls -ltra' }} dist/
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -14,52 +14,73 @@ concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72
 
 jobs:
   wheel:
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
     strategy:
       fail-fast: false
       matrix:
-        # Keep in sync with tests.yml
-        os: [macos-15, ubuntu-24.04, windows-2025]
-        manylinux: [auto]
-        target: [x86_64, aarch64]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         include:
+        - { os: macos-15,     target: x86_64 }
+        - { os: macos-15,     target: aarch64 }
+        - { os: ubuntu-24.04, target: x86_64 }
+        - { os: ubuntu-24.04, target: aarch64 }
         - { os: ubuntu-24.04, target: i686 }
         - { os: ubuntu-24.04, target: armv7 }
         - { os: ubuntu-24.04, target: ppc64le }
         - { os: ubuntu-24.04, target: s390x }
-        - { os: ubuntu-24.04, manylinux: musllinux_1_1 }
-        - { os: windows-2025, target: i686}
-        exclude:
-        - { os: windows-2025, target: aarch64}
+        - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
+        - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
+        - { os: windows-2025, target: x86_64 }
+        - { os: windows-2025, target: i686 }
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
-    # not yet merged https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
-    - uses: Quansight-Labs/setup-python@v5
+    # keep in sync with tests.yml
+    # all python versions need to be present for linking to succeed
+    - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
         architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
-
-    - name: Add python lib to PATH
-      if: startsWith(matrix.os, 'windows')
-      run: Add-Content $env:GITHUB_PATH "${{ env.pythonLocation }}\lib"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+    - uses: Quansight-Labs/setup-python@v5 # https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
+      with:
+        python-version: '3.13t'
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
 
     - uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        manylinux: ${{ matrix.manylinux }}
-        args: --release --out dist --interpreter ${{ matrix.python-version }}
+        manylinux: ${{ matrix.manylinux || 'auto' }}
+        # keep in sync with tests.yml
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
 
-    - run: ${{ ( startsWith(matrix.os, 'windows') && 'dir') || 'ls -ltra' }} dist/
+    - run: ${{ (startsWith(matrix.os, 'windows') && 'dir') || 'ls -ltra' }} dist/
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux }}
+        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
         path: dist
 
   sdist:

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -52,7 +52,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13'${{ (matrix.os == 'windows-2025' && '') || ' 3.13t' }}
+        args: --release --out dist --interpreter ${{ (matrix.os == 'windows-2025' && '3.8 3.9 3.10 3.11 3.12 3.13') || '3.8 3.9 3.10 3.11 3.12 3.13 3.13t' }}
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -14,29 +14,29 @@ concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72
 
 jobs:
   wheel:
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux }}
     strategy:
       fail-fast: false
       matrix:
         include:
-        - { os: macos-15,     target: x86_64 }
-        - { os: macos-15,     target: aarch64 }
-        - { os: ubuntu-24.04, target: x86_64 }
-        - { os: ubuntu-24.04, target: aarch64 }
-        - { os: ubuntu-24.04, target: i686 }
-        - { os: ubuntu-24.04, target: armv7 }
-        - { os: ubuntu-24.04, target: ppc64le }
-        - { os: ubuntu-24.04, target: s390x }
+        - { os: macos-15,     target: x86_64,  manylinux: auto}
+        - { os: macos-15,     target: aarch64, manylinux: auto}
+        - { os: ubuntu-24.04, target: x86_64,  manylinux: auto}
+        - { os: ubuntu-24.04, target: aarch64, manylinux: auto}
+        - { os: ubuntu-24.04, target: i686,    manylinux: auto}
+        - { os: ubuntu-24.04, target: armv7,   manylinux: auto}
+        - { os: ubuntu-24.04, target: ppc64le, manylinux: auto}
+        - { os: ubuntu-24.04, target: s390x,   manylinux: auto}
         - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
         - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
-        - { os: windows-2025, target: x86_64 }
-        - { os: windows-2025, target: i686 }
+        - { os: windows-2025, target: x86_64,  manylinux: auto}
+        - { os: windows-2025, target: i686,    manylinux: auto}
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
-    # keep in sync with tests.yml
+    # keep python versions in sync with tests.yml
     # all python versions need to be present for linking to succeed
     - uses: actions/setup-python@v5
       with:
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: '3.13'
         architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
-    - uses: Quansight-Labs/setup-python@v5 # https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
+    - uses: Quansight-Labs/setup-python@v5 # 3.13t support not yet merged ref https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
       with:
         python-version: '3.13t'
         architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
@@ -70,8 +70,8 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        manylinux: ${{ matrix.manylinux || 'auto' }}
-        # keep in sync with tests.yml
+        manylinux: ${{ matrix.manylinux }}
+        # keep python versions in sync with tests.yml
         args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
@@ -80,7 +80,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
+        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux }}
         path: dist
 
   sdist:

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -18,6 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with tests.yml
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         include:
         - { os: macos-15,     target: x86_64 }
         - { os: macos-15,     target: aarch64 }
@@ -38,36 +40,26 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        # 3.8 is not available by default on windows-2025 runner
-        python-version: "3.8"
-        # x86 python needs to be available for the win32 wheel
-        architecture: ${{ ( matrix.os == 'windows-2025' && matrix.target == 'i686' ) && 'x86' || null }}
-
-    - uses: actions/setup-python@v5
-      with:
-        # pin to the latest supported python version
-        python-version: "3.13"
-        # x86 python needs to be available for the win32 wheel
-        architecture: ${{ ( matrix.os == 'windows-2025' && matrix.target == 'i686' ) && 'x86' || null }}
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
 
     - name: Add python lib to PATH
-      if: matrix.os == 'windows-2025'
+      if: startsWith(matrix.os, 'windows')
       run: Add-Content $env:GITHUB_PATH "${{ env.pythonLocation }}\lib"
 
     - uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
-        # Keep in sync with tests.yml
-        args: --release --out dist --interpreter ${{ (matrix.os == 'windows-2025' && '3.8 3.9 3.10 3.11 3.12 3.13') || '3.8 3.9 3.10 3.11 3.12 3.13 3.13t' }}
+        args: --release --out dist --interpreter ${{ matrix.python-version }}
         rust-toolchain: stable
         docker-options: -e CI
 
-    - run: ${{ (matrix.os == 'windows-2025' && 'dir') || 'ls -ltra' }} dist/
+    - run: ${{ ( startsWith(matrix.os, 'windows') && 'dir') || 'ls -ltra' }} dist/
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
+        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux || 'auto' }}
         path: dist
 
   sdist:

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -14,25 +14,25 @@ concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72
 
 jobs:
   wheel:
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux || 'auto' }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux }}
     strategy:
       fail-fast: false
       matrix:
         # Keep in sync with tests.yml
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         include:
-        - { os: macos-15,     target: x86_64 }
-        - { os: macos-15,     target: aarch64 }
-        - { os: ubuntu-24.04, target: x86_64 }
-        - { os: ubuntu-24.04, target: aarch64 }
-        - { os: ubuntu-24.04, target: i686 }
-        - { os: ubuntu-24.04, target: armv7 }
-        - { os: ubuntu-24.04, target: ppc64le }
-        - { os: ubuntu-24.04, target: s390x }
+        - { os: macos-15,     target: x86_64,  manylinux: auto }
+        - { os: macos-15,     target: aarch64, manylinux: auto }
+        - { os: ubuntu-24.04, target: x86_64,  manylinux: auto }
+        - { os: ubuntu-24.04, target: aarch64, manylinux: auto }
+        - { os: ubuntu-24.04, target: i686,    manylinux: auto }
+        - { os: ubuntu-24.04, target: armv7,   manylinux: auto }
+        - { os: ubuntu-24.04, target: ppc64le, manylinux: auto }
+        - { os: ubuntu-24.04, target: s390x,   manylinux: auto }
         - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
         - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
-        - { os: windows-2025, target: x86_64 }
-        - { os: windows-2025, target: i686 }
+        - { os: windows-2025, target: x86_64,  manylinux: auto }
+        - { os: windows-2025, target: i686,    manylinux: auto }
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        manylinux: ${{ matrix.manylinux || 'auto' }}
+        manylinux: ${{ matrix.manylinux }}
         args: --release --out dist --interpreter ${{ matrix.python-version }}
         rust-toolchain: stable
         docker-options: -e CI
@@ -60,7 +60,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux || 'auto' }}
+        name: dist-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux }}
         path: dist
 
   sdist:

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -14,7 +14,7 @@ concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72
 
 jobs:
   wheel:
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-${{ matrix.manylinux || 'auto' }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    # not yet merged https://github.com/actions/setup-python/pull/973#issuecomment-2495900996
+    - uses: Quansight-Labs/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -3,7 +3,7 @@ name: dists
 on:
   pull_request:
   push:
-    branches: '**'  # not tags
+    branches: [master]
   release:
     types: [released, prereleased]
   workflow_dispatch:  # allows running workflow manually from the Actions tab

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -52,7 +52,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Keep in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
+        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13'${{ (matrix.os == 'windows-2025' && '') || ' 3.13t' }}
         rust-toolchain: stable
         docker-options: -e CI
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -43,6 +43,10 @@ jobs:
         # x86 python needs to be available for the win32 wheel
         architecture: ${{ ( matrix.os == 'windows-2025' && matrix.target == 'i686' ) && 'x86' || null }}
 
+    - name: Add python lib to PATH
+      if: matrix.os == 'windows-2025'
+      run: Add-Content $env:GITHUB_PATH "${{ env.pythonLocation }}\lib"
+
     - uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
@@ -51,8 +55,6 @@ jobs:
         args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.13t'
         rust-toolchain: stable
         docker-options: -e CI
-      env:
-        LIBPATH: ${{ env.pythonLocation }}\lib
 
     - run: ${{ (matrix.os == 'windows-2025' && 'dir') || 'ls -ltra' }} dist/
 

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -38,6 +38,13 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
+        # 3.8 is not available by default on windows-2025 runner
+        python-version: "3.8"
+        # x86 python needs to be available for the win32 wheel
+        architecture: ${{ ( matrix.os == 'windows-2025' && matrix.target == 'i686' ) && 'x86' || null }}
+
+    - uses: actions/setup-python@v5
+      with:
         # pin to the latest supported python version
         python-version: "3.13"
         # x86 python needs to be available for the win32 wheel

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -19,20 +19,19 @@ jobs:
       fail-fast: false
       matrix:
         # Keep in sync with tests.yml
+        os: [macos-15, ubuntu-24.04, windows-2025]
+        manylinux: [auto]
+        target: [x86_64, aarch64]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         include:
-        - { os: macos-15,     target: x86_64,  manylinux: auto }
-        - { os: macos-15,     target: aarch64, manylinux: auto }
-        - { os: ubuntu-24.04, target: x86_64,  manylinux: auto }
-        - { os: ubuntu-24.04, target: aarch64, manylinux: auto }
-        - { os: ubuntu-24.04, target: i686,    manylinux: auto }
-        - { os: ubuntu-24.04, target: armv7,   manylinux: auto }
-        - { os: ubuntu-24.04, target: ppc64le, manylinux: auto }
-        - { os: ubuntu-24.04, target: s390x,   manylinux: auto }
-        - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
-        - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
-        - { os: windows-2025, target: x86_64,  manylinux: auto }
-        - { os: windows-2025, target: i686,    manylinux: auto }
+        - { os: ubuntu-24.04, target: i686 }
+        - { os: ubuntu-24.04, target: armv7 }
+        - { os: ubuntu-24.04, target: ppc64le }
+        - { os: ubuntu-24.04, target: s390x }
+        - { os: ubuntu-24.04, manylinux: musllinux_1_1 }
+        - { os: windows-2025, target: i686}
+        exclude:
+        - { os: windows-2025, target: aarch64}
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -19,18 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { os: macos-latest,   target: x86_64 }
-        - { os: macos-latest,   target: aarch64 }
-        - { os: ubuntu-latest,  target: x86_64 }
-        - { os: ubuntu-latest,  target: aarch64 }
-        - { os: ubuntu-latest,  target: i686 }
-        - { os: ubuntu-latest,  target: armv7 }
-        - { os: ubuntu-latest,  target: ppc64le }
-        - { os: ubuntu-latest,  target: s390x }
-        - { os: ubuntu-latest,  target: x86_64,  manylinux: musllinux_1_1 }
-        - { os: ubuntu-latest,  target: aarch64, manylinux: musllinux_1_1 }
-        - { os: windows-latest, target: x86_64 }
-        - { os: windows-latest, target: i686 }
+        - { os: macos-15,     target: x86_64 }
+        - { os: macos-15,     target: aarch64 }
+        - { os: ubuntu-24.04, target: x86_64 }
+        - { os: ubuntu-24.04, target: aarch64 }
+        - { os: ubuntu-24.04, target: i686 }
+        - { os: ubuntu-24.04, target: armv7 }
+        - { os: ubuntu-24.04, target: ppc64le }
+        - { os: ubuntu-24.04, target: s390x }
+        - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
+        - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
+        - { os: windows-2025, target: x86_64 }
+        - { os: windows-2025, target: i686 }
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,7 +41,7 @@ jobs:
         # pin to the latest supported python version
         python-version: "3.13"
         # x86 python needs to be available for the win32 wheel
-        architecture: ${{ ( matrix.os == 'windows-latest' && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ ( matrix.os == 'windows-2025' && matrix.target == 'i686' ) && 'x86' || null }}
 
     - uses: PyO3/maturin-action@v1
       with:
@@ -52,7 +52,7 @@ jobs:
         rust-toolchain: stable
         docker-options: -e CI
 
-    - run: ${{ (matrix.os == 'windows-latest' && 'dir') || 'ls -ltra' }} dist/
+    - run: ${{ (matrix.os == 'windows-2025' && 'dir') || 'ls -ltra' }} dist/
 
     - uses: actions/upload-artifact@v4
       with:
@@ -61,7 +61,7 @@ jobs:
 
   sdist:
     name: sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
@@ -79,7 +79,7 @@ jobs:
   publish:
     if: github.event_name == 'release'
     needs: [wheel, sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write  # softprops/action-gh-release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: '**'  # not tags
+    branches: [master]
   workflow_dispatch:  # allows running workflow manually from the Actions tab
 
 concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72408109

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 neon = ["blake3/neon"]
 
 [dependencies]
-blake3 = { version = "1.5", features = ["mmap", "rayon"] }
-hex = "0.4.2"
+blake3 = { version = "1.5.5", features = ["mmap", "rayon"] }
+hex = "0.4.3"
 pyo3 = { version = "0.23.3", features = ["extension-module"] }
-rayon = "1.2.1"
+rayon = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ neon = ["blake3/neon"]
 [dependencies]
 blake3 = { version = "1.5", features = ["mmap", "rayon"] }
 hex = "0.4.2"
-pyo3 = { version = "0.23.3", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { version = "0.23.3", features = ["extension-module"] }
 rayon = "1.2.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# blake3-py [![Actions Status](https://github.com/oconnor663/blake3-py/workflows/tests/badge.svg)](https://github.com/oconnor663/blake3-py/actions) [![PyPI version](https://badge.fury.io/py/blake3.svg)](https://pypi.python.org/pypi/blake3)
+# blake3-py [![tests](https://github.com/oconnor663/blake3-py/actions/workflows/tests.yml/badge.svg?branch=master&event=push)](https://github.com/oconnor663/blake3-py/actions/workflows/tests.yml) [![PyPI version](https://badge.fury.io/py/blake3.svg)](https://pypi.python.org/pypi/blake3)
 
 Python bindings for the [official Rust implementation of
 BLAKE3](https://github.com/BLAKE3-team/BLAKE3), based on


### PR DESCRIPTION
it seems we have CI rot coming from external/upstream changes somewhere in the past two weeks: just tried releasing 1.0.1 https://github.com/oconnor663/blake3-py/compare/fc75159...4f172e2 and we're no longer green