### PR TITLE
Add minimum supported Rust version 1.66

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         #   - dists.yml
         #   - the c_impl tests below
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        rust-toolchain: [stable, beta, nightly]
+        rust-toolchain: ["1.66", stable, beta, nightly]
         platform: [
           { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu", name: "ubuntu-x64" },
           { os: "macos-13",       python-architecture: "x64", rust-target: "x86_64-apple-darwin",      name: "macos-x64" },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ homepage = "https://github.com/oconnor663/blake3-py"
 license = "CC0-1.0 OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
+# MSRV, keep in sync with .github/workflows/tests.yml
+rust-version = "1.66"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Rust 1.83 bumped the `Cargo.lock` format to `v4`. Specify and test a lower MSRV to force `Cargo.lock` format `v3`. The oldest working rustc version is 1.66:

```
error: package `constant_time_eq v0.3.1` cannot be built because it requires rustc 1.66.0 or newer
```

Fixes: #56