### PR TITLE
Add LICENSE file to wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blake3"
-version = "1.0.4"
+dynamic = ["version"]
 
 [build-system]
 requires = ["maturin>=1.0,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "blake3"
+version = "1.0.4"
+
 [build-system]
 requires = ["maturin>=1.0,<2"]
 build-backend = "maturin"


### PR DESCRIPTION
The wheels distributed on pypi don't include the License. 

Add a project section with the minimum required name and version fields. This allows maturin to add the license file into the wheel.