### PR TITLE
Fix MyPy typing complaints on Python 3.8, with regression test

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # keep python versions in sync with tests.yml
+    # keep python versions in sync with
+    #   - pyproject.toml
+    #   - tests.yml
     # all python versions need to be present for linking to succeed
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,10 @@ jobs:
     strategy:
       matrix:
         # Keep in sync with:
+        #   - pyproject.toml
         #   - dists.yml
         #   - the c_impl tests below
+        #   - the mypy checks below
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         rust-toolchain: ["1.66", stable, beta, nightly]
         platform: [
@@ -60,8 +62,10 @@ jobs:
     strategy:
       matrix:
         # Keep in sync with:
+        #   - pyproject.toml
         #   - dists.yml
         #   - the rust_impl tests above
+        #   - the mypy checks below
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         platform: [
           # This list should be kept in sync with dists.yml.
@@ -106,13 +110,21 @@ jobs:
   mypy:
     name: "mypy"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Keep in sync with:
+        #   - pyproject.toml
+        #   - dists.yml
+        #   - the rust_impl tests above
+        #   - the c_impl tests above
+        python-version: ["3.8", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       # We use numpy to test the error case of trying to hash a strided buffer.
       - name: Install pytest, numpy, and mypy
         run: pip install pytest numpy mypy
       - name: Run mypy
-        run: python -u -m mypy --strict tests/test_blake3.py
+        run: python -u -m mypy --strict blake3.pyi tests/test_blake3.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ neon = ["blake3/neon"]
 blake3 = { version = "1.5.5", features = ["mmap", "rayon"] }
 hex = "0.4.3"
 pyo3 = { version = "0.25.0", features = ["extension-module"] }
-rayon = "1.10.0"
+rayon = "1.10.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ neon = ["blake3/neon"]
 blake3 = { version = "1.5.5", features = ["mmap", "rayon"] }
 hex = "0.4.3"
 pyo3 = { version = "0.25.0", features = ["extension-module"] }
-rayon = "1.10.*"
+rayon = "~1.10.0"
+rayon-core = "~1.12.1"

--- a/blake3.pyi
+++ b/blake3.pyi
@@ -1,5 +1,9 @@
 from os import PathLike
-from collections.abc import Buffer
+import sys
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
 
 __version__: str = ...
 

--- a/c_impl/setup.py
+++ b/c_impl/setup.py
@@ -264,4 +264,8 @@ setuptools.setup(
     license="CC0-1.0 OR Apache-2.0",
     url="https://github.com/oconnor663/blake3-py/tree/master/c_impl",
     ext_modules=[prepare_extension()],
+    # keep dependencies in sync with pyproject.toml
+    install_requires=[
+        "typing_extensions >= 4.6.0; python_version <= '3.11'",
+    ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,13 @@
 [project]
 name = "blake3"
 dynamic = ["version"]
+# keep python versions in sync with
+#   - .github/workflows/dists.yml
+#   - .github/workflows/tests.yml
 requires-python = ">=3.8"
+dependencies = [
+    "typing_extensions >= 4.6.0; python_version <= '3.11'",
+]
 
 [build-system]
 requires = ["maturin>=1.0,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ dynamic = ["version"]
 #   - .github/workflows/dists.yml
 #   - .github/workflows/tests.yml
 requires-python = ">=3.8"
+# keep dependencies in sync with c_impl/setup.py
 dependencies = [
     "typing_extensions >= 4.6.0; python_version <= '3.11'",
 ]

--- a/tests/test_blake3.py
+++ b/tests/test_blake3.py
@@ -7,7 +7,15 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
-from typing import Any
+from typing import (
+    Any,
+    Dict,
+    cast,
+)
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
 
 from blake3 import blake3, __version__
 
@@ -152,10 +160,10 @@ def test_strided_array_fails() -> None:
     strided = numpy.lib.stride_tricks.as_strided(unstrided, shape=[2], strides=[2])
     assert bytes(strided) == bytes([1, 3])
     # Unstrided works fine.
-    blake3(unstrided)
+    blake3(cast(Buffer, unstrided))
     try:
         # But strided fails.
-        blake3(strided)
+        blake3(cast(Buffer, strided))
     # We get BufferError in Rust and ValueError in C.
     except (BufferError, ValueError):
         pass
@@ -419,7 +427,7 @@ def test_output_overflows_isize() -> None:
 # https://github.com/mkdocstrings/mkdocstrings/issues/451 and
 # https://github.com/PyO3/maturin/discussions/1365
 def test_module_name() -> None:
-    global_scope: dict[str, Any] = {}
+    global_scope: Dict[str, Any] = {}
     exec(f"from {blake3.__module__} import blake3 as foobar", global_scope)
     assert global_scope["foobar"] is blake3
 


### PR DESCRIPTION
Introduces new install time dependency `typing_extensions` on Python <= 3.11.

Fixes #73
Refs #75