### PR TITLE
Bump macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         rust-toolchain: ["1.80", stable, beta, nightly]
         platform: [
           { os: "ubuntu-latest",  python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu", name: "ubuntu-x64" },
-          { os: "macos-13",       python-architecture: "x64", rust-target: "x86_64-apple-darwin",      name: "macos-x64" },
+          { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin",      name: "macos-x64" },
           # disabled for now ref https://github.com/actions/setup-python/issues/855#issuecomment-2196137381
           # { os: "macos-14",       python-architecture: "x64", rust-target: "aarch64-apple-darwin",     name: "macos-arm64" },
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc",     name: "windows-x86" },
@@ -70,7 +70,7 @@ jobs:
         platform: [
           # This list should be kept in sync with dists.yml.
           { os: "ubuntu-latest",  python-architecture: "x64", name: "ubuntu-x64" },
-          { os: "macos-13",       python-architecture: "x64", name: "macos-x64" },
+          { os: "macos-15-intel", python-architecture: "x64", name: "macos-x64" },
           # disabled for now ref https://github.com/actions/setup-python/issues/855#issuecomment-2196137381
           # { os: "macos-14",       python-architecture: "x64", name: "macos-arm64" },
           { os: "windows-latest", python-architecture: "x86", name: "windows-x86" },


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/