### PR TITLE
ci: add riscv64 target to wheel build matrix

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -27,6 +27,7 @@ jobs:
         - { os: ubuntu-24.04, target: armv7,   manylinux: auto}
         - { os: ubuntu-24.04, target: ppc64le, manylinux: auto}
         - { os: ubuntu-24.04, target: s390x,   manylinux: auto}
+        - { os: ubuntu-24.04, target: riscv64, manylinux: auto}
         - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
         - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
         - { os: windows-2025, target: x86_64,  manylinux: auto}


### PR DESCRIPTION
## Summary

Add `riscv64` to the maturin-action wheel build matrix so that `linux_riscv64` wheels are built and published to PyPI.

maturin-action cross-compiles via `riscv64gc-unknown-linux-gnu` cargo target — no QEMU or additional infrastructure needed.

## Evidence

- Tested wheel: [`blake3-1.0.8-cp313-cp313-manylinux_2_34_riscv64.whl`](https://github.com/gounthar/riscv64-python-wheels/releases/download/v2026.03.11-cp313/blake3-1.0.8-cp313-cp313-manylinux_2_34_riscv64.whl)
- Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz)
- Build time: ~3 min
- Imports and passes basic smoke test on riscv64

## Context

- `riscv64gc-unknown-linux-gnu` is a Rust tier-2 target with std available
- maturin-action handles cross-compilation transparently
- RISC-V hardware is shipping (SiFive, SpacemiT, Sophgo SG2044)

Fixes #102

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).