### PR TITLE
[codex] Add MSYS2 MinGW CI coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,45 @@ jobs:
       - name: Run pytest
         run: uv run --no-sync pytest --verbose
 
+  msys2_mingw:
+    name: msys2-mingw-${{ matrix.msystem }}
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        include:
+          - msystem: UCRT64
+          - msystem: MINGW64
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            git
+          pacboy: >-
+            gcc:p
+            python:p
+            python-pip:p
+            python-maturin:p
+            rust:p
+      - run: python tests/python_info.py
+      - name: Show native toolchain versions
+        run: |
+          rustc --version
+          cargo --version
+          gcc --version
+          python -m pip --version
+          maturin --version
+      - name: Build and install from source
+        run: python -m pip install --no-build-isolation --no-deps --verbose .
+      - name: Test import, __version__, __file__
+        run: python -c "import blake3; print(blake3.__version__); print(blake3.__file__)"
+
   cargo_lock:
     name: cargo-lock
     runs-on: ubuntu-latest


### PR DESCRIPTION
(experiment, not yet reviewed by me, Codex description below)

## Summary

Add a focused MSYS2/MinGW CI job to the tests workflow so source builds are exercised under MSYS2 Python and the MinGW Rust/GCC toolchain.

The job currently runs for UCRT64 and MINGW64, installs MSYS2-packaged Python, pip, maturin, Rust, and GCC, then builds this repo from source with pip and smoke-tests the installed extension import. This is intended to catch failures like #109 where PyO3/MinGW linking breaks even though the normal Windows/MSVC path still passes.

## Validation

- Parsed `.github/workflows/tests.yml` with Ruby YAML
- Ran `git diff --check`

The actual MSYS2 build needs to run on GitHub Actions.