### PR TITLE
Add CI support for Windows ARM64 builds

### DIFF
--- a/.github/workflows/dists.yml
+++ b/.github/workflows/dists.yml
@@ -30,8 +30,10 @@ jobs:
         - { os: ubuntu-24.04, target: riscv64, manylinux: auto}
         - { os: ubuntu-24.04, target: x86_64,  manylinux: musllinux_1_1 }
         - { os: ubuntu-24.04, target: aarch64, manylinux: musllinux_1_1 }
-        - { os: windows-2025, target: x86_64,  manylinux: auto}
-        - { os: windows-2025, target: i686,    manylinux: auto}
+        - { os: windows-2025,   target: x86_64,  manylinux: auto}
+        - { os: windows-2025,   target: i686,    manylinux: auto, architecture: x86}
+        # Windows ARM64 CPython is available starting with Python 3.11.
+        - { os: windows-11-arm, target: aarch64, manylinux: auto, architecture: arm64, interpreters: '3.11 3.12 3.13 3.14'}
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,40 +44,43 @@ jobs:
     #   - tests.yml
     # all python versions need to be present for linking to succeed
     - uses: actions/setup-python@v6
+      if: ${{ matrix.interpreters == null }}
       with:
         python-version: '3.8'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
+      if: ${{ matrix.interpreters == null }}
       with:
         python-version: '3.9'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
+      if: ${{ matrix.interpreters == null }}
       with:
         python-version: '3.10'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.14'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
 
     - uses: PyO3/maturin-action@v1.51.0
       with:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux }}
         # keep python versions in sync with tests.yml
-        args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 3.14'
+        args: --release --out dist --interpreter '${{ matrix.interpreters || '3.8 3.9 3.10 3.11 3.12 3.13 3.14' }}'
         rust-toolchain: stable
         docker-options: -e CI
 
@@ -85,7 +90,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: '3.14t'
-        architecture: ${{ ( startsWith(matrix.os, 'windows') && matrix.target == 'i686' ) && 'x86' || null }}
+        architecture: ${{ matrix.architecture || null }}
     - uses: PyO3/maturin-action@v1.51.0
       with:
         target: ${{ matrix.target }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,13 @@ jobs:
           { os: "macos-latest",   python-target: "macos-aarch64",  rust-target: "aarch64-apple-darwin",     name: "macos-arm64" },
           { os: "windows-latest", python-target: "windows-x86",    rust-target: "i686-pc-windows-msvc",     name: "windows-x86" },
           { os: "windows-latest", python-target: "windows-x86_64", rust-target: "x86_64-pc-windows-msvc",   name: "windows-x64" },
+          { os: "windows-11-arm", python-target: "windows-aarch64", rust-target: "aarch64-pc-windows-msvc",  name: "windows-arm64" },
         ]
+        # Windows ARM64 CPython is available starting with Python 3.11.
+        exclude:
+          - { python-version: "3.8",  platform: { os: "windows-11-arm", python-target: "windows-aarch64", rust-target: "aarch64-pc-windows-msvc", name: "windows-arm64" } }
+          - { python-version: "3.9",  platform: { os: "windows-11-arm", python-target: "windows-aarch64", rust-target: "aarch64-pc-windows-msvc", name: "windows-arm64" } }
+          - { python-version: "3.10", platform: { os: "windows-11-arm", python-target: "windows-aarch64", rust-target: "aarch64-pc-windows-msvc", name: "windows-arm64" } }
       fail-fast: false
     env:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
@@ -62,7 +68,13 @@ jobs:
           { os: "macos-latest",   python-target: "macos-aarch64",  name: "macos-arm64" },
           { os: "windows-latest", python-target: "windows-x86",    name: "windows-x86" },
           { os: "windows-latest", python-target: "windows-x86_64", name: "windows-x64" },
+          { os: "windows-11-arm", python-target: "windows-aarch64", name: "windows-arm64" },
         ]
+        # Windows ARM64 CPython is available starting with Python 3.11.
+        exclude:
+          - { python-version: "3.8",  platform: { os: "windows-11-arm", python-target: "windows-aarch64", name: "windows-arm64" } }
+          - { python-version: "3.9",  platform: { os: "windows-11-arm", python-target: "windows-aarch64", name: "windows-arm64" } }
+          - { python-version: "3.10", platform: { os: "windows-11-arm", python-target: "windows-aarch64", name: "windows-arm64" } }
       fail-fast: false
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Hi @oconnor663, I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
 So I updates the CI workflows to add support for Windows ARM64 builds and tests. Could you please help to review? Thanks.
 
The changes ensure that Windows ARM64 is only targeted for Python 3.11+ (since that's when CPython ARM64 builds are available), and simplify how the architecture is specified in the workflows.

**Platform and architecture support:**

* Added Windows ARM64 (`windows-11-arm`, `aarch64`) to the build and test matrices in `.github/workflows/dists.yml` and `.github/workflows/tests.yml`, ensuring builds and tests are run for this platform. [[1]](diffhunk://#diff-2ffa37ee2713c77ad695d2a416f162d680b031d4ae772d7f3828d5803abb4ddaL34-R36) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR32-R38) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR71-R77)
* Excluded Python versions earlier than 3.11 for Windows ARM64, since CPython ARM64 is only available from 3.11 onwards. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR32-R38) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR71-R77)

**Workflow configuration improvements:**

* Replaced the previous conditional architecture selection logic with a more consistent `architecture` matrix field, simplifying how the Python setup actions are configured. [[1]](diffhunk://#diff-2ffa37ee2713c77ad695d2a416f162d680b031d4ae772d7f3828d5803abb4ddaL34-R36) [[2]](diffhunk://#diff-2ffa37ee2713c77ad695d2a416f162d680b031d4ae772d7f3828d5803abb4ddaR47-R83) [[3]](diffhunk://#diff-2ffa37ee2713c77ad695d2a416f162d680b031d4ae772d7f3828d5803abb4ddaL88-R93)
* Updated the `maturin-action` invocation to use a matrix-driven list of Python interpreters, allowing per-platform interpreter customization.
